### PR TITLE
installing package fails

### DIFF
--- a/.nuspec
+++ b/.nuspec
@@ -8,6 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="file">LICENSE.txt</license>
     <projectUrl>https://github.com/JBKLabs/dotnet-runtime-configuration-injection</projectUrl>
+    <repository type="git" url="https://github.com/JBKLabs/dotnet-runtime-configuration-injection"/>
     <description>Package Description</description>
     <dependencies>
       <group targetFramework=".NETStandard2.0">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Fixed
+- issue where package could not be installed by adding the `repositoryUrl` field ([#1](https://github.com/JBKLabs/dotnet-runtime-configuration-injection/issues/1))

--- a/RuntimeConfigurationInjection/RuntimeConfigurationInjection.csproj
+++ b/RuntimeConfigurationInjection/RuntimeConfigurationInjection.csproj
@@ -2,11 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.0.1</Version>
+    <Version>0.0.2</Version>
     <Authors>JBKLabs</Authors>
     <Company>JBKnowledge</Company>
     <PackageId>JBKnowledge.Extensions.RuntimeConfigurationInjection</PackageId>
-    <PackageProjectUrl>https://github.com/JBKLabs/dotnet-runtime-configuration-injection</PackageProjectUrl>
+    <PackageProjectUrl></PackageProjectUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <RepositoryUrl>https://github.com/JBKLabs/dotnet-runtime-configuration-injection</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RuntimeConfigurationInjection/RuntimeConfigurationInjection.csproj
+++ b/RuntimeConfigurationInjection/RuntimeConfigurationInjection.csproj
@@ -7,7 +7,6 @@
     <Company>JBKnowledge</Company>
     <PackageId>JBKnowledge.Extensions.RuntimeConfigurationInjection</PackageId>
     <PackageProjectUrl>https://github.com/JBKLabs/dotnet-runtime-configuration-injection</PackageProjectUrl>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/JBKLabs/dotnet-runtime-configuration-injection</RepositoryUrl>
   </PropertyGroup>
 

--- a/RuntimeConfigurationInjection/RuntimeConfigurationInjection.csproj
+++ b/RuntimeConfigurationInjection/RuntimeConfigurationInjection.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.0.2</Version>
+    <Version>0.0.1</Version>
     <Authors>JBKLabs</Authors>
     <Company>JBKnowledge</Company>
     <PackageId>JBKnowledge.Extensions.RuntimeConfigurationInjection</PackageId>
-    <PackageProjectUrl></PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/JBKLabs/dotnet-runtime-configuration-injection</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/JBKLabs/dotnet-runtime-configuration-injection</RepositoryUrl>
   </PropertyGroup>


### PR DESCRIPTION
Closes #1.

Add `RepositoryUrl` field to be used instead of PackageProjectUrl per this [blog post](https://github.blog/changelog/2019-11-01-github-package-registry-nuget-must-use-repository-field-in-the-nuspec/).

- [ ] Publish .nuspec to local nuget repo. [steps for this](https://medium.com/@churi.vibhav/creating-and-using-a-local-nuget-package-repository-9f19475d6af8)
- [ ] Install the nuget package into a project that already has `Microsoft.Extensions.Configuration` installed (se-service should work)
- [ ] Confirm install works